### PR TITLE
Add microbenchmark

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{bench,config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/bench/bench.exs
+++ b/bench/bench.exs
@@ -1,0 +1,36 @@
+from_utc_jobs = %{
+  "Tzdata" => fn {iso_days, time_zone} ->
+    Tzdata.TimeZoneDatabase.time_zone_period_from_utc_iso_days(iso_days, time_zone)
+  end,
+  "Tz" => fn {iso_days, time_zone} ->
+    Tz.TimeZoneDatabase.time_zone_period_from_utc_iso_days(iso_days, time_zone)
+  end,
+  "Zoneinfo" => fn {iso_days, time_zone} ->
+    Zoneinfo.TimeZoneDatabase.time_zone_period_from_utc_iso_days(iso_days, time_zone)
+  end
+}
+
+ndt_to_iso = fn ndt ->
+  Calendar.ISO.naive_datetime_to_iso_days(
+    ndt.year,
+    ndt.month,
+    ndt.day,
+    ndt.hour,
+    ndt.minute,
+    ndt.second,
+    {0, 6}
+  )
+end
+
+inputs = [
+  {"converting now", {ndt_to_iso.(NaiveDateTime.utc_now()), "America/New_York"}}
+]
+
+Benchee.run(from_utc_jobs,
+  #  parallel: 4,
+  warmup: 5,
+  time: 30,
+  memory_time: 1,
+  inputs: inputs,
+  formatters: [Benchee.Formatters.Console]
+)

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Zoneinfo.MixProject do
       description: description(),
       package: package(),
       compilers: compilers(Mix.env()),
+      aliases: aliases(),
       make_targets: ["all"],
       make_clean: ["clean"],
       start_permanent: Mix.env() == :prod,
@@ -26,6 +27,10 @@ defmodule Zoneinfo.MixProject do
         "hex.build": :docs
       }
     ]
+  end
+
+  defp aliases() do
+    [bench: ["run bench/bench.exs"]]
   end
 
   def compilers(env) when env in [:dev, :test] do
@@ -59,6 +64,7 @@ defmodule Zoneinfo.MixProject do
   defp deps do
     [
       # No prod dependencies. These are only for dev and test.
+      {:benchee, "~> 1.0", only: :dev},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},
       {:elixir_make, "> 0.6.0", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
   "certifi": {:hex, :certifi, "2.5.3", "70bdd7e7188c804f3a30ee0e7c99655bc35d8ac41c23e12325f36ab449b70651", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "ed516acb3929b101208a9d700062d520f3953da3b6b918d866106ffa980e1c10"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
   "elixir_make": {:hex, :elixir_make, "0.6.2", "7dffacd77dec4c37b39af867cedaabb0b59f6a871f89722c25b28fcd4bd70530", [:mix], [], "hexpm", "03e49eadda22526a7e5279d53321d1cced6552f344ba4e03e619063de75348d9"},


### PR DESCRIPTION
Here are initial results - take with a grain of salt:

The OTP 24 JIT was enabled for this one.

```
Operating System: Linux
CPU Information: AMD Ryzen Threadripper 2950X 16-Core Processor
Number of Available Cores: 32
Available memory: 31.29 GB
Elixir 1.11.3
Erlang 24.0-rc1
Benchmark suite executing with the following configuration:
warmup: 5 s
time: 30 s
memory time: 1 s
parallel: 1
inputs: converting now
Estimated total run time: 1.80 min
Benchmarking Tz with input converting now...
Benchmarking Tzdata with input converting now...
Benchmarking Zoneinfo with input converting now...
##### With input converting now #####
Name               ips        average  deviation         median         99th %
Tz           1246.66 K        0.80 μs  ±3182.10%        0.71 μs        1.53 μs
Zoneinfo      307.16 K        3.26 μs  ±1044.56%        2.85 μs        5.22 μs
Tzdata         26.65 K       37.53 μs    ±47.25%       37.08 μs       47.01 μs
Comparison:
Tz           1246.66 K
Zoneinfo      307.16 K - 4.06x slower +2.45 μs
Tzdata         26.65 K - 46.79x slower +36.73 μs
Memory usage statistics:
Name        Memory usage
Tz                 168 B
Zoneinfo           152 B - 0.90x memory usage -16 B
Tzdata            3424 B - 20.38x memory usage +3256 B
**All measurements for memory usage were the same**
```

And an ARM M1 Mac (no JIT):

```text
Operating System: macOS
CPU Information: Apple M1
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.11.3
Erlang 24.0-rc1
Benchmark suite executing with the following configuration:
warmup: 5 s
time: 30 s
memory time: 1 s
parallel: 1
inputs: converting now
Estimated total run time: 1.80 min
Benchmarking Tz with input converting now...
Benchmarking Tzdata with input converting now...
Benchmarking Zoneinfo with input converting now...
##### With input converting now #####
Name               ips        average  deviation         median         99th %
Tz           1167.55 K        0.86 μs  ±5467.35%        0.99 μs        0.99 μs
Zoneinfo      368.66 K        2.71 μs   ±948.34%        1.99 μs        8.99 μs
Tzdata         47.89 K       20.88 μs    ±67.26%       19.99 μs       29.99 μs
Comparison:
Tz           1167.55 K
Zoneinfo      368.66 K - 3.17x slower +1.86 μs
Tzdata         47.89 K - 24.38x slower +20.03 μs
Memory usage statistics:
Name        Memory usage
Tz                 168 B
Zoneinfo           152 B - 0.90x memory usage -16 B
Tzdata            3512 B - 20.90x memory usage +3344 B
**All measurements for memory usage were the same**
```
