### PR TITLE
Fix time type processing

### DIFF
--- a/lib/zoneinfo/tzif.ex
+++ b/lib/zoneinfo/tzif.ex
@@ -173,10 +173,13 @@ defmodule Zoneinfo.TZif do
         {utoff, get_tz_abbr(raw_tz_designations, tz_index), std_or_dst(dst)}
       end
 
-    {first_utoff, first_abbr, _} = hd(lt_record)
+    types = for <<type <- transition_types>>, do: Enum.at(lt_record, type)
+
+    #  Local time for timestamps before the first transition is specified by the
+    #  first time type (time type 0).
+    {first_utoff, first_abbr, _} = hd(types)
     prehistory_record = {-2_147_483_647, first_utoff, 0, first_abbr}
 
-    types = for <<type <- transition_types>>, do: Enum.at(lt_record, type)
     guess = first_utc_offset(types, nil)
 
     process_records(times, types, guess, [prehistory_record])


### PR DESCRIPTION
Discovered from nerves-time/nerves_time_zones#76

In TZVERSION >= 2021d, `zic -r` adds the `-00` abbreviation to the `TZDATA_LATEST_TIME` of the range which indicates that anything past that time has unspecified local time. The problem we have is that this latest time is technically the first six-octet local time record in the data, but when parsing the transitition types, it is actually at index 1.

So creating a prehistory record for the range `START_OF_TIME -> TZDATA_EARLIEST_DATE`, we would pull the first local time type data we saw, which be the latest time with an offset of `-00` specifying no local time.

However, [RFC8536bis section 3.2, page 11](https://www.ietf.org/archive/id/draft-murchison-rfc8536bis-05.html#name-tzif-data-block) states:

> Local time for timestamps before the first transition is specified by the
> first time type (time type 0).

So this changes to set the prehistory abbreviation and offset from the first position in the parsed transition types which puts time type 0 at the head of the list