### PR TITLE
Fetch gz versions of tzdata and tzcode 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ install_system_deps: &install_system_deps
   run:
     name: Install system dependencies
     command: |
-        apk add build-base lzip
+        apk add build-base curl
 
 jobs:
   build_elixir_1_13_otp_24:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ zoneinfo-*.tar
 
 # Downloaded tzdb archive
 /tzdb-*.tar.lz
+/dl

--- a/Makefile
+++ b/Makefile
@@ -112,3 +112,6 @@ clean:
 	$(RM) -r $(BUILD) $(PREFIX)
 
 .PHONY: all clean calling_from_make
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:


### PR DESCRIPTION
This removes the need for lzip when testing