### PR TITLE
Add protection from testing against mismatch versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ $(BUILD)/tzdb/version.h: $(BUILD)/tzdb/version
 ### End copied definitions
 
 $(BUILD)/tzdb/zic: $(BUILD)/tzdb $(BUILD)/tzdb/zic.c $(BUILD)/tzdb/version.h
-	$(CC_FOR_BUILD) -o $@ $(BUILD)/tzdb/zic.c
+	$(CC_FOR_BUILD) -DHAVE_GETRANDOM=false -o $@ $(BUILD)/tzdb/zic.c
 
 $(PREFIX)/zoneinfo: $(BUILD)/tzdb/zic $(PREFIX) Makefile
-	cd $(BUILD)/tzdb && ./zic -d $@ $(ZIC_OPTIONS) $(TDATA)
+	cd $(BUILD)/tzdb && ./zic -d $@ $(ZIC_OPTIONS) $(TDATA) && cp $(BUILD)/tzdb/version $@/
 
 $(TZDB_FILENAME):
 	wget $(TZDB_URL)

--- a/lib/zoneinfo.ex
+++ b/lib/zoneinfo.ex
@@ -78,6 +78,16 @@ defmodule Zoneinfo do
   @spec get_metadata(String.t()) :: {:ok, Zoneinfo.Meta.t()} | {:error, atom()}
   defdelegate get_metadata(time_zone), to: Zoneinfo.Cache, as: :meta
 
+  @doc """
+  Return the time zone database version
+
+  This attempts to read `<tzpath>/version` and returns `:unknown` if non-existent.
+  This allows external libraries to provide the version of TZ compiled that is
+  currently being used with Zoneinfo
+  """
+  @spec tz_version() :: String.t() | :unknown
+  defdelegate tz_version(), to: Zoneinfo.TimeZoneDatabase, as: :version
+
   defp contains_tzif?(path) do
     case File.open(path, [:read], &contains_tzif_helper/1) do
       {:ok, result} -> result

--- a/lib/zoneinfo/time_zone_database.ex
+++ b/lib/zoneinfo/time_zone_database.ex
@@ -42,6 +42,21 @@ defmodule Zoneinfo.TimeZoneDatabase do
     end
   end
 
+  @doc """
+  Return the time zone database version
+
+  This attempts to read `<tzpath>/version` and returns `:unknown` if non-existent.
+  This allows external libraries to provide the version of TZ compiled that is
+  currently being used with Zoneinfo
+  """
+  @spec version() :: String.t() | :unknown
+  def version() do
+    case File.read([Zoneinfo.tzpath(), "/version"]) do
+      {:ok, ver} -> String.trim(ver)
+      _ -> :unknown
+    end
+  end
+
   defp find_period_for_utc_secs(secs, periods) do
     period = Enum.find(periods, fn {time, _, _, _} -> secs >= time end)
     {:ok, period_to_map(period)}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,21 @@
+current = Zoneinfo.tz_version()
+
+# iana_version/0 introduced in v0.17
+fun = if function_exported?(Tz, :iana_version, 0), do: :iana_version, else: :version
+tz = apply(Tz, fun, [])
+
+if current != tz do
+  Mix.raise("""
+  The current TZVERSION compiled does not match the Tz library version
+  and tests may not be considered valid:
+
+    expected: #{tz}
+    got: #{current}
+
+  Please update :tz dependency for the version expected
+  """)
+end
+
 ExUnit.start(exclude: [slow: true])
 
 # Run the following for a more thorough test


### PR DESCRIPTION
Just a convenience for test. It adds the ability to look for a `<tzpath>/version` file. This can then be used to compare your expected TZversion.

In our case, we make sure our version matches `Tz.iana_version` since that is considered the source of truth in our tests