### PR TITLE
Bump test tzdb to 2021a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 # Since this is for test purposes, be sure this matches what the tz (or tzdata)
 # libraries use or you'll get discrepancies that are ok.
-TZDB_VERSION=2020f
+TZDB_VERSION=2021a
 TZDB_NAME=tzdb-$(TZDB_VERSION)
 TZDB_FILENAME=$(TZDB_NAME).tar.lz
 TZDB_URL=https://data.iana.org/time-zones/releases/$(TZDB_FILENAME)

--- a/mix.exs
+++ b/mix.exs
@@ -78,7 +78,7 @@ defmodule Zoneinfo.MixProject do
       {:elixir_make, "> 0.6.0", only: [:dev, :test]},
       # Locked dependencies to guarantee that tz and tzdata use the same IANA time zone database
       # It's ok to update. Change the version in the Makefile.
-      {:tz, "~> 0.12.0", only: [:dev, :test]},
+      {:tz, "~> 0.20.1", only: [:dev, :test]},
       {:tzdata, "~> 1.1.0", only: [:dev, :test]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -22,7 +22,7 @@
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
-  "tz": {:hex, :tz, "0.12.0", "48659c720f948eed467bc16be26d82100b8e6da4961de96d87c5ba7e88521521", [:mix], [{:castore, "~> 0.1.5", [hex: :castore, repo: "hexpm", optional: true]}, {:mint, "~> 1.0", [hex: :mint, repo: "hexpm", optional: true]}], "hexpm", "f1bf4cb5178e7be2eb5b7df2830ae3e1535141dc06f88b4909f1431db58edbf1"},
+  "tz": {:hex, :tz, "0.20.1", "6909937c50095206bd0084db0d3f93ca6ef06b269af7521bf23a1d6491c35736", [:mix], [{:castore, "~> 0.1.11", [hex: :castore, repo: "hexpm", optional: true]}, {:mint, "~> 1.4", [hex: :mint, repo: "hexpm", optional: true]}], "hexpm", "355a63968e1b31f9a8c0615e8840cc48779448cb91784c35a0c2e5f7ec8fe6f0"},
   "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
The tests pass here. This is intended to provide a more recent check
point that timezone offsets get calculated properly.

Note: I would have updated to 2021c, but tz didn't ship with that
version so the exhaustive check that the regression tests would have
picked up expected differences. 2021a is pretty close, though. 2021d is
the location of the `zic` update. See #19.
