### PR TITLE
Protect against Cache GenServer issues

### DIFF
--- a/test/zoneinfo/cache_test.exs
+++ b/test/zoneinfo/cache_test.exs
@@ -2,6 +2,8 @@ defmodule Zoneinfo.CacheTest do
   use ExUnit.Case, async: false
   alias Zoneinfo.Cache
 
+  import ExUnit.CaptureLog
+
   test "looks up timezone that exists" do
     assert {:ok, _} = Cache.get("America/New_York")
   end
@@ -20,5 +22,13 @@ defmodule Zoneinfo.CacheTest do
     Process.sleep(50)
 
     assert :ets.info(Zoneinfo.Cache, :size) == 0
+  end
+
+  test "uncached version returned when not started" do
+    capture_log(fn -> Application.stop(:zoneinfo) end)
+
+    assert {:ok, _} = Cache.get("America/Chicago")
+
+    Application.start(:zoneinfo)
   end
 end


### PR DESCRIPTION
The Cache GenServer that holds the ETS table is sometimes down and
sometimes goes down when a request is outstanding so there's a timeout.
Code that needs calendar calculations is just not able to deal
exceptions coming from here, so try harder to make things work. The
changes are:

1. Handle GenServer exits when Cache.get/1 is called. The handling just
   tries to load the time zone in the current process instead.
2. When falling back to loading time zone data in the current process,
   turn exceptions into error returns.
3. In the Cache Genserver, check whether the time zone has been loaded
   by a previous request to try to clear the request queue faster for
   the case where multiple processes try to get the same time zone at
   the same time.
4. Halve the timeout for Cache.get/1, so that if it times out, that
   GenServer.call timeouts (5s) don't immediately cascade to the source
   making all of these changes moot.
