### PR TITLE
Support TZDIR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The final step is to specify the location of the time zone files. Zoneinfo looks
 at the following locations:
 
 1. The `:tzpath` key in the application environment
-2. The `TZPATH` environment variable
+2. The `TZDIR` environment variable
 3. `/usr/share/zoneinfo`
 
 Since `/usr/share/zoneinfo` is the default on Linux and OSX, you may not need to

--- a/lib/zoneinfo.ex
+++ b/lib/zoneinfo.ex
@@ -10,7 +10,7 @@ defmodule Zoneinfo do
 
   Time zone data is loaded from the path returned by `tzpath/0`. The default
   is to use `/usr/share/zoneinfo`, but that may be changed by setting the
-  `$TZPATH` environment or adding the following to your project's `config.exs`:
+  `$TZDIR` environment or adding the following to your project's `config.exs`:
 
   ```elixir
   config :zoneinfo, tzpath: "/custom/location"
@@ -45,7 +45,10 @@ defmodule Zoneinfo do
   """
   @spec tzpath() :: binary()
   def tzpath() do
+    # TZDIR is preferred. TZPATH was originally used and is supported for
+    # backwards compatibility.
     with nil <- Application.get_env(:zoneinfo, :tzpath),
+         nil <- System.get_env("TZDIR"),
          nil <- System.get_env("TZPATH") do
       "/usr/share/zoneinfo"
     end

--- a/test/zoneinfo_test.exs
+++ b/test/zoneinfo_test.exs
@@ -34,6 +34,16 @@ defmodule ZoneinfoTest do
 
     test "OS environment" do
       old_path = clear_path()
+      System.put_env("TZDIR", "tzpath_environment")
+
+      assert Zoneinfo.tzpath() == "tzpath_environment"
+
+      :os.unsetenv(~c"TZDIR")
+      pop_path(old_path)
+    end
+
+    test "deprecated TZPATH OS environment" do
+      old_path = clear_path()
       System.put_env("TZPATH", "tzpath_environment")
 
       assert Zoneinfo.tzpath() == "tzpath_environment"


### PR DESCRIPTION
This uses the more standard `$TZDIR` environment variable for overriding
the zoneinfo directory. If `$TZDIR` isn't specified, the original
`$TZPATH` is used for backwards compatibility.

Fixes #34.
