### PR TITLE
TECH-4317: Update Alpine Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
           matrix:
             parameters:
               tag: [
-                1.15.7-erlang-26.2.1-alpine-3.18.4,
+                1.15.7-erlang-26.1.2-alpine-3.18.6,
                 1.14.2-erlang-25.1.2-alpine-3.16.2,
                 1.13.4-erlang-25.1.2-alpine-3.16.2,
                 1.12.3-erlang-24.3.4.6-alpine-3.15.6,


### PR DESCRIPTION
Vulnerabilities were found in 3.18.4, updating to 3.18.6.